### PR TITLE
Run CI workflows on self-hosted runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
     - main
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Deploy
     steps:
     - uses: google-github-actions/auth@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Test
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- Switch `build`, `deploy`, and `test` workflows from `ubuntu-latest` to `self-hosted` runners.

## Notes for reviewer
- The self-hosted runner(s) must have:
  - Docker + buildx available (for `build.yaml`)
  - `kubectl` available (for `deploy.yaml`)
  - `asdf` available (for `test.yaml`)
- If we want to scope to a more specific runner pool, we can change `self-hosted` to a label list like `[self-hosted, linux, x64]`.

## Test plan
- [ ] Confirm a self-hosted runner is online and picks up the `test` workflow on this PR.
- [ ] After merge, verify `build` workflow runs and pushes the image to Artifact Registry.
- [ ] Verify `deploy` workflow runs after a successful build and updates the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)