### PR TITLE
Install kubectl in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: self-hosted
     name: Deploy
     steps:
+    - uses: azure/setup-kubectl@v4
     - uses: google-github-actions/auth@v1
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}


### PR DESCRIPTION
## Summary
- Add `azure/setup-kubectl@v4` as the first step in the Deploy job so `kubectl` is available on the self-hosted runner before `kubectl set image` runs.

## Test plan
- [ ] Next merge to `main` triggers the Deploy workflow and the `kubectl set image` step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)