### PR TITLE
Track per-project egress, then redirect /files to a CDN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 **Environment variables (optional):**
 - `base_url` — download URL prefix (default: `https://dropbox.deploys-files.app/`)
 - `api_endpoint` — deploys.app API base URL (default: `https://api.deploys.app`, override with internal address in production)
-- `cdn_domain` — when set, `GET /files/{fn}` records the download metric (counted against `attrs.Size`) and 307-redirects to `https://{cdn_domain}/{fn}`. The CDN edge is expected to fetch its origin at `https://dropbox.deploys.app/_cdn/files/{fn}`, which streams the file unauthenticated and without metrics. In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly. Unset = original streaming behavior.
+- `cdn_domain` — when set, `GET /files/{fn}` records the download metric (counted against `attrs.Size`) and 307-redirects to `https://{cdn_domain}/{fn}`. The CDN edge is expected to fetch its origin at `https://dropbox.deploys.app/_cdn/{fn}`, which streams the file unauthenticated and without metrics. In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly. Unset = original streaming behavior.
 - `PORT` — listen port (default: `8080`)
 - `log_level` — slog level (default: info)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 **Environment variables (optional):**
 - `base_url` — download URL prefix (default: `https://dropbox.deploys-files.app/`)
 - `api_endpoint` — deploys.app API base URL (default: `https://api.deploys.app`, override with internal address in production)
+- `cdn_domain` — when set, `GET /files/{fn}` records the download metric (counted against `attrs.Size`) and 307-redirects to `https://{cdn_domain}/files/{fn}`. The CDN edge is expected to fetch its origin at `https://dropbox.deploys.app/_cdn/files/{fn}`, which streams the file unauthenticated and without metrics. In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly. Unset = original streaming behavior.
 - `PORT` — listen port (default: `8080`)
 - `log_level` — slog level (default: info)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 **Environment variables (optional):**
 - `base_url` — download URL prefix (default: `https://dropbox.deploys-files.app/`)
 - `api_endpoint` — deploys.app API base URL (default: `https://api.deploys.app`, override with internal address in production)
-- `cdn_domain` — when set, `GET /files/{fn}` records the download metric (counted against `attrs.Size`) and 307-redirects to `https://{cdn_domain}/files/{fn}`. The CDN edge is expected to fetch its origin at `https://dropbox.deploys.app/_cdn/files/{fn}`, which streams the file unauthenticated and without metrics. In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly. Unset = original streaming behavior.
+- `cdn_domain` — when set, `GET /files/{fn}` records the download metric (counted against `attrs.Size`) and 307-redirects to `https://{cdn_domain}/{fn}`. The CDN edge is expected to fetch its origin at `https://dropbox.deploys.app/_cdn/files/{fn}`, which streams the file unauthenticated and without metrics. In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly. Unset = original streaming behavior.
 - `PORT` — listen port (default: `8080`)
 - `log_level` — slog level (default: info)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 - `bucket_name` — GCS bucket name
 
 **Environment variables (optional):**
-- `base_url` — download URL prefix (default: `https://dropbox.deploys-files.app/`)
+- `base_url` — download URL prefix (default: `https://dropbox.deploys.app/files/`)
 - `api_endpoint` — deploys.app API base URL (default: `https://api.deploys.app`, override with internal address in production)
 - `cdn_domain` — when set, `GET /files/{fn}` records the download metric (counted against `attrs.Size`) and 307-redirects to `https://{cdn_domain}/{fn}`. The CDN edge is expected to fetch its origin at `https://dropbox.deploys.app/_cdn/{fn}`, which streams the file unauthenticated and without metrics. In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly. Unset = original streaming behavior.
 - `PORT` — listen port (default: `8080`)
@@ -50,4 +50,4 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 ## Notes
 
 - `schema.sql` targets PostgreSQL; `project_id` is `text` (the API returns string IDs)
-- The download domain (`base_url`) differs from the upload domain — files are served from a separate host
+- `base_url` is the public download prefix (`https://dropbox.deploys.app/files/`); it shares the service host and resolves to the `GET /files/{fn}` route, which streams directly or 307s to the CDN (see `cdn_domain`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 **Environment variables (optional):**
 - `base_url` — download URL prefix (default: `https://dropbox.deploys.app/files/`)
 - `api_endpoint` — deploys.app API base URL (default: `https://api.deploys.app`, override with internal address in production)
-- `cdn_domain` — when set, `GET /files/{fn}` records the download metric (counted against `attrs.Size`) and 307-redirects to `https://{cdn_domain}/{fn}`. The CDN edge is expected to fetch its origin at `https://dropbox.deploys.app/_cdn/{fn}`, which streams the file unauthenticated and without metrics. In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly. Unset = original streaming behavior.
+- `cdn_base_url` — full URL prefix (including scheme and trailing slash, e.g. `https://cdn.example.com/`). When set, `GET /files/{fn}` records the download metric (counted against `attrs.Size`) and 307-redirects to `{cdn_base_url}{fn}`. The CDN edge is expected to fetch its origin at `https://dropbox.deploys.app/_cdn/{fn}`, which streams the file unauthenticated and without metrics. In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly. Unset = original streaming behavior.
 - `PORT` — listen port (default: `8080`)
 - `log_level` — slog level (default: info)
 
@@ -50,4 +50,4 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 ## Notes
 
 - `schema.sql` targets PostgreSQL; `project_id` is `text` (the API returns string IDs)
-- `base_url` is the public download prefix (`https://dropbox.deploys.app/files/`); it shares the service host and resolves to the `GET /files/{fn}` route, which streams directly or 307s to the CDN (see `cdn_domain`)
+- `base_url` is the public download prefix (`https://dropbox.deploys.app/files/`); it shares the service host and resolves to the `GET /files/{fn}` route, which streams directly or 307s to the CDN (see `cdn_base_url`)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Docker image is built and pushed automatically on push to `main`. See `.github/w
 |---------------|----------------------------------------------------------|
 | `db_url`      | PostgreSQL connection string                             |
 | `bucket_name` | GCS bucket name                                          |
-| `base_url`    | Download URL prefix (default: `https://dropbox-files.deploys.app/`) |
+| `base_url`    | Download URL prefix (default: `https://dropbox.deploys.app/files/`) |
 | `PORT`        | Listen port (default: `8080`)                            |
 
 ---
@@ -74,7 +74,7 @@ File data binary
 {
 	"ok": true,
 	"result": {
-		"downloadUrl": "https://dropbox-files.deploys.app/1<filename>",
+		"downloadUrl": "https://dropbox.deploys.app/files/<filename>",
 		"expiresAt": "2020-01-01T01:01:01Z"
 	}
 }

--- a/files.go
+++ b/files.go
@@ -41,7 +41,7 @@ func (a *App) fileHandler(w http.ResponseWriter, r *http.Request) {
 	if a.CDNDomain != "" && !isInternalClient(r) {
 		downloadCount.WithLabelValues(projectID).Inc()
 		egressBytes.WithLabelValues(projectID).Add(float64(attrs.Size))
-		http.Redirect(w, r, "https://"+a.CDNDomain+"/files/"+fn, http.StatusTemporaryRedirect)
+		http.Redirect(w, r, "https://"+a.CDNDomain+"/"+fn, http.StatusTemporaryRedirect)
 		return
 	}
 

--- a/files.go
+++ b/files.go
@@ -38,10 +38,10 @@ func (a *App) fileHandler(w http.ResponseWriter, r *http.Request) {
 	// actual bytes) and redirect. Cache hits never come back to this origin,
 	// so the bill is an over-approximation; that matches the registry
 	// pattern and is what /_internal/calculate-dropbox-usages assumes.
-	if a.CDNDomain != "" && !isInternalClient(r) {
+	if a.CDNBaseURL != "" && !isInternalClient(r) {
 		downloadCount.WithLabelValues(projectID).Inc()
 		egressBytes.WithLabelValues(projectID).Add(float64(attrs.Size))
-		http.Redirect(w, r, "https://"+a.CDNDomain+"/"+fn, http.StatusTemporaryRedirect)
+		http.Redirect(w, r, a.CDNBaseURL+fn, http.StatusTemporaryRedirect)
 		return
 	}
 

--- a/files.go
+++ b/files.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/acoshift/pgsql/pgctx"
 	"github.com/moonrhythm/cachestore"
+	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
 )
 
@@ -32,6 +33,46 @@ func (a *App) fileHandler(w http.ResponseWriter, r *http.Request) {
 
 	projectID := lookupFileProject(r.Context(), fn)
 
+	// When a CDN is configured and the caller is not in-cluster, record the
+	// download as if we were serving the full file (the CDN will handle the
+	// actual bytes) and redirect. Cache hits never come back to this origin,
+	// so the bill is an over-approximation; that matches the registry
+	// pattern and is what /_internal/calculate-dropbox-usages assumes.
+	if a.CDNDomain != "" && !isInternalClient(r) {
+		downloadCount.WithLabelValues(projectID).Inc()
+		egressBytes.WithLabelValues(projectID).Add(float64(attrs.Size))
+		http.Redirect(w, r, "https://"+a.CDNDomain+"/files/"+fn, http.StatusTemporaryRedirect)
+		return
+	}
+
+	a.streamFile(w, r, fn, attrs, projectID)
+}
+
+// cdnFileHandler is the origin endpoint the CDN edge fetches from. It is
+// unauthenticated — file URLs are 86-char crypto-random and only reachable
+// if you know them — and skips the redirect/metrics so the CDN sees a
+// plain streaming response.
+func (a *App) cdnFileHandler(w http.ResponseWriter, r *http.Request) {
+	fn := r.PathValue("fn")
+
+	attrs, err := a.Bucket.Attributes(r.Context(), fn)
+	if err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	a.streamFile(w, r, fn, attrs, "")
+}
+
+// streamFile copies the object body to w with the cached headers. When
+// projectID is non-empty, download_count and egress_bytes are bumped by
+// the actual transferred bytes. Used by both the direct-stream path
+// (no CDN configured) and the unauthenticated _cdn origin path.
+func (a *App) streamFile(w http.ResponseWriter, r *http.Request, fn string, attrs *blob.Attributes, projectID string) {
 	reader, err := a.Bucket.NewReader(r.Context(), fn, nil)
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
@@ -54,9 +95,13 @@ func (a *App) fileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Length", strconv.FormatInt(attrs.Size, 10))
 
-	downloadCount.WithLabelValues(projectID).Inc()
+	if projectID != "" {
+		downloadCount.WithLabelValues(projectID).Inc()
+	}
 	n, _ := io.Copy(w, reader)
-	egressBytes.WithLabelValues(projectID).Add(float64(n))
+	if projectID != "" {
+		egressBytes.WithLabelValues(projectID).Add(float64(n))
+	}
 }
 
 func lookupFileProject(ctx context.Context, fn string) string {

--- a/files_test.go
+++ b/files_test.go
@@ -155,3 +155,174 @@ func TestLookupFileProject_NotFound(t *testing.T) {
 		t.Errorf("lookupFileProject = %q, want empty for missing fn", got)
 	}
 }
+
+func TestFileHandler_CDNRedirect(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+	app.CDNDomain = "cdn.example.com"
+
+	bw, err := bkt.NewWriter(t.Context(), "cdnfile", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bw.Write([]byte("hello world"))
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/files/cdnfile", nil)
+	r = r.WithContext(db.Ctx())
+	r.SetPathValue("fn", "cdnfile")
+	w := httptest.NewRecorder()
+	app.fileHandler(w, r)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want 307", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "https://cdn.example.com/files/cdnfile" {
+		t.Errorf("Location = %q, want https://cdn.example.com/files/cdnfile", loc)
+	}
+	if got := w.Body.Len(); got > 100 {
+		// the default redirect body is small ("<a href=...>"); we shouldn't
+		// be streaming the object.
+		t.Errorf("body length = %d, expected a short redirect body", got)
+	}
+}
+
+func TestFileHandler_CDNInternalClientStreams(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+	app.CDNDomain = "cdn.example.com"
+
+	bw, err := bkt.NewWriter(t.Context(), "internalfile", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bw.Write([]byte("internal bytes"))
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/files/internalfile", nil)
+	r = r.WithContext(db.Ctx())
+	r.SetPathValue("fn", "internalfile")
+	r.Header.Set("X-Real-Ip", "10.0.0.5") // private IP -> internal
+	w := httptest.NewRecorder()
+	app.fileHandler(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (internal callers stream)", w.Code)
+	}
+	if got := w.Body.String(); got != "internal bytes" {
+		t.Errorf("body = %q, want %q", got, "internal bytes")
+	}
+}
+
+func TestFileHandler_CDNRedirectPublicXRealIP(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+	app.CDNDomain = "cdn.example.com"
+
+	bw, err := bkt.NewWriter(t.Context(), "publicfile", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bw.Write([]byte("public"))
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/files/publicfile", nil)
+	r = r.WithContext(db.Ctx())
+	r.SetPathValue("fn", "publicfile")
+	r.Header.Set("X-Real-Ip", "203.0.113.5") // public IP -> CDN path
+	w := httptest.NewRecorder()
+	app.fileHandler(w, r)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want 307 (public callers redirect)", w.Code)
+	}
+}
+
+func TestCDNFileHandler_Streams(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+	app.CDNDomain = "cdn.example.com"
+
+	bw, err := bkt.NewWriter(t.Context(), "origin", &blob.WriterOptions{
+		CacheControl: "public, max-age=86400",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bw.Write([]byte("origin bytes"))
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/_cdn/files/origin", nil)
+	r = r.WithContext(db.Ctx())
+	w := httptest.NewRecorder()
+	app.routes().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Body.String(); got != "origin bytes" {
+		t.Errorf("body = %q, want %q", got, "origin bytes")
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "public, max-age=86400" {
+		t.Errorf("Cache-Control = %q", cc)
+	}
+}
+
+func TestCDNFileHandler_NotFound(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	app := newTestApp(newTestBucket(t), authorized)
+	app.CDNDomain = "cdn.example.com"
+
+	r := httptest.NewRequest(http.MethodGet, "/_cdn/files/nope", nil)
+	r = r.WithContext(db.Ctx())
+	w := httptest.NewRecorder()
+	app.routes().ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestIsInternalClient(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"", false},
+		{"not-an-ip", false},
+		{"10.0.0.1", true},
+		{"172.16.5.5", true},
+		{"192.168.1.1", true},
+		{"127.0.0.1", true},
+		{"169.254.1.1", true},
+		{"203.0.113.5", false},
+		{"8.8.8.8", false},
+	}
+	for _, tc := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		if tc.ip != "" {
+			r.Header.Set("X-Real-Ip", tc.ip)
+		}
+		if got := isInternalClient(r); got != tc.want {
+			t.Errorf("isInternalClient(%q) = %v, want %v", tc.ip, got, tc.want)
+		}
+	}
+}

--- a/files_test.go
+++ b/files_test.go
@@ -161,7 +161,7 @@ func TestFileHandler_CDNRedirect(t *testing.T) {
 	db := newTestDB(t)
 	bkt := newTestBucket(t)
 	app := newTestApp(bkt, authorized)
-	app.CDNDomain = "cdn.example.com"
+	app.CDNBaseURL = "https://cdn.example.com/"
 
 	bw, err := bkt.NewWriter(t.Context(), "cdnfile", nil)
 	if err != nil {
@@ -196,7 +196,7 @@ func TestFileHandler_CDNInternalClientStreams(t *testing.T) {
 	db := newTestDB(t)
 	bkt := newTestBucket(t)
 	app := newTestApp(bkt, authorized)
-	app.CDNDomain = "cdn.example.com"
+	app.CDNBaseURL = "https://cdn.example.com/"
 
 	bw, err := bkt.NewWriter(t.Context(), "internalfile", nil)
 	if err != nil {
@@ -227,7 +227,7 @@ func TestFileHandler_CDNRedirectPublicXRealIP(t *testing.T) {
 	db := newTestDB(t)
 	bkt := newTestBucket(t)
 	app := newTestApp(bkt, authorized)
-	app.CDNDomain = "cdn.example.com"
+	app.CDNBaseURL = "https://cdn.example.com/"
 
 	bw, err := bkt.NewWriter(t.Context(), "publicfile", nil)
 	if err != nil {
@@ -255,7 +255,7 @@ func TestCDNFileHandler_Streams(t *testing.T) {
 	db := newTestDB(t)
 	bkt := newTestBucket(t)
 	app := newTestApp(bkt, authorized)
-	app.CDNDomain = "cdn.example.com"
+	app.CDNBaseURL = "https://cdn.example.com/"
 
 	bw, err := bkt.NewWriter(t.Context(), "origin", &blob.WriterOptions{
 		CacheControl: "public, max-age=86400",
@@ -288,7 +288,7 @@ func TestCDNFileHandler_NotFound(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
 	app := newTestApp(newTestBucket(t), authorized)
-	app.CDNDomain = "cdn.example.com"
+	app.CDNBaseURL = "https://cdn.example.com/"
 
 	r := httptest.NewRequest(http.MethodGet, "/_cdn/nope", nil)
 	r = r.WithContext(db.Ctx())

--- a/files_test.go
+++ b/files_test.go
@@ -181,8 +181,8 @@ func TestFileHandler_CDNRedirect(t *testing.T) {
 	if w.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status = %d, want 307", w.Code)
 	}
-	if loc := w.Header().Get("Location"); loc != "https://cdn.example.com/files/cdnfile" {
-		t.Errorf("Location = %q, want https://cdn.example.com/files/cdnfile", loc)
+	if loc := w.Header().Get("Location"); loc != "https://cdn.example.com/cdnfile" {
+		t.Errorf("Location = %q, want https://cdn.example.com/cdnfile", loc)
 	}
 	if got := w.Body.Len(); got > 100 {
 		// the default redirect body is small ("<a href=...>"); we shouldn't

--- a/files_test.go
+++ b/files_test.go
@@ -268,7 +268,7 @@ func TestCDNFileHandler_Streams(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := httptest.NewRequest(http.MethodGet, "/_cdn/files/origin", nil)
+	r := httptest.NewRequest(http.MethodGet, "/_cdn/origin", nil)
 	r = r.WithContext(db.Ctx())
 	w := httptest.NewRecorder()
 	app.routes().ServeHTTP(w, r)
@@ -290,7 +290,7 @@ func TestCDNFileHandler_NotFound(t *testing.T) {
 	app := newTestApp(newTestBucket(t), authorized)
 	app.CDNDomain = "cdn.example.com"
 
-	r := httptest.NewRequest(http.MethodGet, "/_cdn/files/nope", nil)
+	r := httptest.NewRequest(http.MethodGet, "/_cdn/nope", nil)
 	r = r.WithContext(db.Ctx())
 	w := httptest.NewRecorder()
 	app.routes().ServeHTTP(w, r)

--- a/handler.go
+++ b/handler.go
@@ -33,7 +33,7 @@ func (a *App) routes() http.Handler {
 	})
 	mux.HandleFunc("POST /{$}", a.uploadHandler)
 	mux.HandleFunc("GET /files/{fn}", a.fileHandler)
-	mux.HandleFunc("GET /_cdn/files/{fn}", a.cdnFileHandler)
+	mux.HandleFunc("GET /_cdn/{fn}", a.cdnFileHandler)
 	mux.HandleFunc("POST /internal/gc", a.gcHandler)
 	return mux
 }

--- a/handler.go
+++ b/handler.go
@@ -21,7 +21,7 @@ import (
 type App struct {
 	Bucket         *blob.Bucket
 	BaseURL        string
-	CDNDomain      string
+	CDNBaseURL     string
 	InternalSecret string
 	checkAuth      func(ctx context.Context, auth, project, projectID string) AuthResult
 }

--- a/handler.go
+++ b/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -20,6 +21,7 @@ import (
 type App struct {
 	Bucket         *blob.Bucket
 	BaseURL        string
+	CDNDomain      string
 	InternalSecret string
 	checkAuth      func(ctx context.Context, auth, project, projectID string) AuthResult
 }
@@ -31,6 +33,7 @@ func (a *App) routes() http.Handler {
 	})
 	mux.HandleFunc("POST /{$}", a.uploadHandler)
 	mux.HandleFunc("GET /files/{fn}", a.fileHandler)
+	mux.HandleFunc("GET /_cdn/files/{fn}", a.cdnFileHandler)
 	mux.HandleFunc("POST /internal/gc", a.gcHandler)
 	return mux
 }
@@ -132,6 +135,17 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// isInternalClient returns true when the request originates from a
+// private/loopback/link-local IP per the X-Real-Ip header. Internal callers
+// (in-cluster fetches) bypass the CDN redirect and read files directly.
+func isInternalClient(r *http.Request) bool {
+	ip := net.ParseIP(r.Header.Get("X-Real-Ip"))
+	if ip == nil {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast()
 }
 
 func jsonFail(w http.ResponseWriter, msg string, status int) {

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	app := &App{
 		Bucket:         bkt,
 		BaseURL:        config.StringDefault("base_url", "https://dropbox.deploys.app/files/"),
-		CDNDomain:      config.String("cdn_domain"),
+		CDNBaseURL:     config.String("cdn_base_url"),
 		InternalSecret: config.String("internal_secret"),
 	}
 

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func main() {
 	app := &App{
 		Bucket:         bkt,
 		BaseURL:        config.StringDefault("base_url", "https://dropbox.deploys.app/files/"),
+		CDNDomain:      config.String("cdn_domain"),
 		InternalSecret: config.String("internal_secret"),
 	}
 


### PR DESCRIPTION
## Summary
- New `cdn_base_url` env var (full URL prefix, e.g. `https://cdn.example.com/`). When set, `GET /files/{fn}` records the download against the file's project (`deploys_dropbox_download_count` + `deploys_dropbox_egress_bytes` by `attrs.Size`) and 307s to `{cdn_base_url}{fn}`.
- New `GET /_cdn/{fn}` is the unauthenticated origin endpoint the CDN edge fetches from — streams directly with no redirect and no metrics, so cache misses don't double-count.
- In-cluster callers (private/loopback/link-local `X-Real-Ip`) bypass the redirect and stream directly, keeping internal pulls off the public CDN path.
- Same shape as `registry.go::getBlob` + `cdnHandler`.

## Topology
- Public download URL stays `https://dropbox.deploys.app/files/{fn}` (unchanged; apiserver's `DropboxItem.DownloadURL` keeps working).
- That endpoint 307s to `{cdn_base_url}{fn}` (e.g. `https://cdn.example.com/{fn}`).
- CDN edge is configured with origin `https://dropbox.deploys.app/_cdn/{fn}` (unauthenticated, direct stream).

## Tradeoff (matches registry)
Egress is billed by `attrs.Size` per request, not by bytes actually leaving this origin. The CDN absorbs cache hits, so the meter over-counts when callers re-fetch — but `/_internal/calculate-dropbox-usages` already treats `deploys_dropbox_egress_bytes` as the canonical signal, so this matches the registry's convention.

## Test plan
- [x] `go build ./...` and `go test ./... -count=1` pass
- [x] `TestFileHandler_CDNRedirect` — 307 with `Location: {cdn_base_url}{fn}`, short body (no streaming)
- [x] `TestFileHandler_CDNInternalClientStreams` — private X-Real-Ip → streams 200
- [x] `TestFileHandler_CDNRedirectPublicXRealIP` — public X-Real-Ip → 307
- [x] `TestCDNFileHandler_Streams` — `/_cdn/{fn}` returns object body
- [x] `TestCDNFileHandler_NotFound` — 404 for missing object
- [x] `TestIsInternalClient` — private/loopback/link-local vs public IPs
- [ ] Deploy with `cdn_base_url` set; confirm the dashboard's egress numbers track real usage and the CDN cache hit ratio looks sane

🤖 Generated with [Claude Code](https://claude.com/claude-code)