### PR TITLE
Persist the signed download token in files.token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 - The URL path component is a `token` = `fn` + `"-"` + `sig`, currently 45 chars total. `fn` is 24 random chars `[0-9A-Za-z]` (~143 bits of entropy); `sig` is 20 hex chars of HMAC-SHA256 truncated to 80 bits, keyed by `sign_key`.
 - The `-` separator lets us change `fnLen` later without invalidating tokens that are already in circulation — `parseToken` splits structurally on the separator, not by fixed position. Since `fn` is alphanumeric and `sig` is hex, neither side can contain a `-`.
 - `parseToken(SignKey, token)` runs first in both `fileHandler` and `cdnFileHandler` and 404s on any mismatch — DDoS attempts that don't know `sign_key` never reach the DB or GCS.
-- `fn` is what we store in the bucket and the `files.fn` column. The full token only appears in URLs.
+- `fn` is what we store in the bucket and the `files.fn` column. The full token is also persisted in `files.token` so the api's `dropbox.List` can rebuild download URLs without holding `sign_key`; it's otherwise only meaningful in URLs.
 
 **Request flow (`handler.go`):**
 1. Parse `Authorization` header + `project`/`projectId` from query params or `param-*` headers (query params take precedence)

--- a/handler.go
+++ b/handler.go
@@ -74,6 +74,9 @@ func (a *App) uploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	expiresAt := time.Now().UTC().Add(time.Duration(ttlDays) * 24 * time.Hour)
 	fn := generateFilename()
+	// The signed token is the public URL component. Persist it so the api's
+	// dropbox.List can rebuild download URLs without holding SignKey.
+	token := makeToken(a.SignKey, fn)
 
 	opts := &blob.WriterOptions{
 		CacheControl: "public, max-age=86400",
@@ -105,9 +108,9 @@ func (a *App) uploadHandler(w http.ResponseWriter, r *http.Request) {
 	uploadBytes.WithLabelValues(authResult.Project.ID).Add(float64(n))
 
 	if _, err := pgctx.Exec(r.Context(), `
-		INSERT INTO files (fn, project_id, size, filename, ttl, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6)
-	`, fn, authResult.Project.ID, n, filename, ttlDays, expiresAt); err != nil {
+		INSERT INTO files (fn, project_id, size, filename, ttl, expires_at, token)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, fn, authResult.Project.ID, n, filename, ttlDays, expiresAt, token); err != nil {
 		slog.Error("insert file metadata", "error", err)
 	}
 
@@ -115,7 +118,7 @@ func (a *App) uploadHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{
 		"ok": true,
 		"result": map[string]any{
-			"downloadUrl": a.BaseURL + makeToken(a.SignKey, fn),
+			"downloadUrl": a.BaseURL + token,
 			"expiresAt":   expiresAt.Format(time.RFC3339),
 		},
 	})

--- a/handler_test.go
+++ b/handler_test.go
@@ -225,6 +225,17 @@ func TestUpload_Success(t *testing.T) {
 	if n := db.CountFiles(t); n != 1 {
 		t.Errorf("db files = %d, want 1", n)
 	}
+
+	// The signed token in the URL must be persisted verbatim so the api's
+	// dropbox.List (which has no SignKey) can rebuild the same download URL.
+	wantToken := strings.TrimPrefix(resp.Result.DownloadURL, "https://example.com/")
+	var gotToken string
+	if err := db.DB.QueryRowContext(context.Background(), `SELECT token FROM files`).Scan(&gotToken); err != nil {
+		t.Fatal(err)
+	}
+	if gotToken != wantToken {
+		t.Errorf("stored token = %q, want %q (matching downloadUrl)", gotToken, wantToken)
+	}
 }
 
 func TestUpload_TTL(t *testing.T) {

--- a/schema.sql
+++ b/schema.sql
@@ -5,7 +5,8 @@ create table files (
 	filename   text        not null,
 	ttl        integer     not null,
 	created_at timestamptz not null default now(),
-	expires_at timestamptz
+	expires_at timestamptz,
+	token      text        not null default ''
 );
 create index files_project_id_created_at_idx on files (project_id, created_at);
 create index files_expires_at_idx on files (expires_at);

--- a/schema/03_token.sql
+++ b/schema/03_token.sql
@@ -1,0 +1,1 @@
+alter table files add column token text not null default '';


### PR DESCRIPTION
## Summary

- Store the full signed download token (`fn-{hmac}`) in a new `files.token` column at upload time, so the api's `dropbox.List` can rebuild working download URLs without holding `sign_key`.

## Why

PR #17 made the HMAC signature mandatory: `GET /files/{token}` runs `parseToken` first and 404s anything without a valid tag. But `dropbox.List` (in apiserver) builds its `downloadUrl` from the bare `fn` — it has no `sign_key`, so every link it returns is a dead `/files/{fn}` that fails the HMAC check. Persisting the token dropbox already computes is the simplest fix; the alternative (sharing `sign_key` with the api) couples key rotation across services.

## How

- `schema/03_token.sql` + `schema.sql`: add `token text not null default ''`. The default keeps the migration safe for existing rows — they carry an empty token until they self-expire (≤7-day max TTL), which is no worse than today (links are already broken).
- `uploadHandler` computes the token once, writes it to the new column, and reuses it for the response `downloadUrl` (previously recomputed inline).

## Schema migration

```sql
alter table files add column token text not null default '';
```

(dropbox's `schema/*.sql` migrator is not run at startup — apply out-of-band, same as other columns.)

## Deploy ordering

1. Apply the migration above.
2. Deploy **dropbox** (this PR) — new uploads start populating `token`.
3. Deploy **apiserver** ([deploys-app/apiserver companion PR](https://github.com/deploys-app/apiserver)) — reads `token` for `dropbox.List`.

## Test plan

- [x] `go test ./...` passes
- `TestUpload_Success` now asserts the token in `downloadUrl` is persisted verbatim to `files.token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)