### PR TITLE
chore: modernize to Go 1.26 idioms

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -238,7 +238,7 @@ func TestCheckAuth_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	results := make([]AuthResult, N)
 	var wg sync.WaitGroup
 	start := make(chan struct{})
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()

--- a/files.go
+++ b/files.go
@@ -177,10 +177,7 @@ func (a *App) cdnFileHandler(w http.ResponseWriter, r *http.Request) {
 	// doesn't overwrite it. If we have no expires_at to work from
 	// (insert-failed upload), fall through to the bucket's value.
 	if !meta.ExpiresAt.IsZero() {
-		remaining := time.Until(meta.ExpiresAt)
-		if remaining < 0 {
-			remaining = 0
-		}
+		remaining := max(time.Until(meta.ExpiresAt), 0)
 		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", int(remaining.Seconds())))
 	}
 

--- a/files_test.go
+++ b/files_test.go
@@ -196,7 +196,7 @@ func TestLookupFile_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	results := make([]fileMeta, N)
 	var wg sync.WaitGroup
 	start := make(chan struct{})
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -701,14 +701,14 @@ func TestFileHandler_InvalidTokenRejected(t *testing.T) {
 	forgedDiffKey := makeToken([]byte("not-the-real-key"), goodFn)
 
 	cases := map[string]string{
-		"empty":             "",
-		"short":             "short",
-		"path-traversal":    "../../etc/passwd",
-		"no-separator":      strings.Repeat("a", fnLen+sigLen),
-		"empty-fn":          tokenSep + signFilename(testSignKey, ""),
-		"empty-sig":         goodFn + tokenSep,
-		"tampered-sig":      tamperedSig,
-		"forged-other-key":  forgedDiffKey,
+		"empty":            "",
+		"short":            "short",
+		"path-traversal":   "../../etc/passwd",
+		"no-separator":     strings.Repeat("a", fnLen+sigLen),
+		"empty-fn":         tokenSep + signFilename(testSignKey, ""),
+		"empty-sig":        goodFn + tokenSep,
+		"tampered-sig":     tamperedSig,
+		"forged-other-key": forgedDiffKey,
 	}
 	for name, token := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -523,7 +523,7 @@ func TestGenerateFilename_DistributionLooksUniform(t *testing.T) {
 	// once, which would fail catastrophically if a whole half of the
 	// alphabet got dropped (e.g. by an off-by-one in the reject bound).
 	counts := map[byte]int{}
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		for j := 0; j < len(generateFilename()); j++ {
 			counts[generateFilename()[j]]++
 		}
@@ -560,7 +560,7 @@ func TestSignFilename_KeyMatters(t *testing.T) {
 
 func TestParseToken_RoundTripsGeneratedToken(t *testing.T) {
 	t.Parallel()
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		fn := generateFilename()
 		token := makeToken(testSignKey, fn)
 		if want := fnLen + 1 + sigLen; len(token) != want {

--- a/tu/tu.go
+++ b/tu/tu.go
@@ -65,7 +65,10 @@ func Setup() *Context {
 }
 
 // CountFiles returns the number of rows in the files table.
-func (c *Context) CountFiles(t interface{ Helper(); Fatal(...any) }) int {
+func (c *Context) CountFiles(t interface {
+	Helper()
+	Fatal(...any)
+}) int {
 	t.Helper()
 	var n int
 	if err := c.DB.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM files`).Scan(&n); err != nil {


### PR DESCRIPTION
## What

Behavior-preserving modernization to Go 1.26 idioms, applied with the official `modernize` analyzer from `golang.org/x/tools` (version-aware against this module's `go` directive).

### Changes
- Replace an `if remaining < 0 { remaining = 0 }` clamp with `max()` in `cdnFileHandler` (Go 1.21)
- Convert `for i := 0; i < N; i++` counter loops to `for i := range N` / `for range N` in tests (Go 1.22)
- `gofmt`-normalize a multi-method inline interface type in `tu/tu.go` (pre-existing formatting)

### Safety
- **No functional change.**
- `go build`, `go vet`, and `go test ./...` all pass (handler tests run against the CockroachDB test server).
- `omitempty`→`omitzero` JSON-tag rewrites were deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)