### PR TITLE
handler: accept a project sid or numeric ID in the upload project param

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 - `fn` is what we store in the bucket and the `files.fn` column. The full token is also persisted in `files.token` so the api's `dropbox.List` can rebuild download URLs without holding `sign_key`; it's otherwise only meaningful in URLs.
 
 **Request flow (`handler.go`):**
-1. Parse `Authorization` header + `project`/`projectId` from query params or `param-*` headers (query params take precedence). `project` is the project **sid** (stable slug, e.g. `my-project`) — this is the canonical identifier and what every caller passes; `projectId` is the **numeric** project ID. Both are relayed to `me.authorized`, which resolves `project` by sid and requires `projectId` to be numeric, so a sid must go in `project`.
+1. Parse `Authorization` header + `project`/`projectId` from query params or `param-*` headers (query params take precedence). `project` accepts **either** a project **sid** (stable slug, e.g. `my-project`) **or** a numeric project ID; `projectId` is always the numeric ID. Because a sid always starts with a letter (api `ReValidSID`: `^[a-z][a-z0-9\-]*[^\-]$`), an all-digit `project` is unambiguously an ID, so `uploadHandler` routes it to `projectID` (an explicit `projectId` still wins). Both are relayed to `me.authorized`, which resolves `project` by sid and `projectId` by numeric ID.
 2. Authorize via `checkAuth()` in `auth.go`
 3. Parse TTL (1–7 days, default 1) and optional filename the same way
 4. Generate a 24-char alphanumeric `fn` (`generateFilename`, rejection-sampled to stay unbiased)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 - `fn` is what we store in the bucket and the `files.fn` column. The full token is also persisted in `files.token` so the api's `dropbox.List` can rebuild download URLs without holding `sign_key`; it's otherwise only meaningful in URLs.
 
 **Request flow (`handler.go`):**
-1. Parse `Authorization` header + `project`/`projectId` from query params or `param-*` headers (query params take precedence)
+1. Parse `Authorization` header + `project`/`projectId` from query params or `param-*` headers (query params take precedence). `project` is the project **sid** (stable slug, e.g. `my-project`) — this is the canonical identifier and what every caller passes; `projectId` is the **numeric** project ID. Both are relayed to `me.authorized`, which resolves `project` by sid and requires `projectId` to be numeric, so a sid must go in `project`.
 2. Authorize via `checkAuth()` in `auth.go`
 3. Parse TTL (1–7 days, default 1) and optional filename the same way
 4. Generate a 24-char alphanumeric `fn` (`generateFilename`, rejection-sampled to stay unbiased)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Endpoint: https://dropbox.deploys.app/
 |-----------------|----------|-----------|---------------------------------|
 | Authorization   | required | string    | Authorization token             |
 | Param-Ttl       | optional | number    | 1-7, default 1                  |
-| Param-Project   | required | string    | Project sid (stable slug)       |
+| Param-Project   | required | string    | Project sid (stable slug) or numeric project ID |
 | Param-Filename  | optional | string    | Filename in Content-Disposition |
 
 #### Query Parameters
@@ -58,8 +58,8 @@ Endpoint: https://dropbox.deploys.app/
 | Name       | Type     | Data Type | Description                     |
 |------------|----------|-----------|---------------------------------|
 | ttl        | optional | number    | 1-7, default 1                  |
-| project    | required | string    | Project sid (stable slug)       |
-| projectId  | optional | string    | Numeric project ID (alternative to `project` sid) |
+| project    | required | string    | Project sid (stable slug) **or** numeric project ID — an all-digit value is treated as the ID |
+| projectId  | optional | string    | Numeric project ID (same as passing a numeric `project`) |
 | filename   | optional | string    | Filename in Content-Disposition |
 
 > Query parameters take precedence over headers when both are provided.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Endpoint: https://dropbox.deploys.app/
 |-----------------|----------|-----------|---------------------------------|
 | Authorization   | required | string    | Authorization token             |
 | Param-Ttl       | optional | number    | 1-7, default 1                  |
-| Param-Project   | required | string    | Project name                    |
+| Param-Project   | required | string    | Project sid (stable slug)       |
 | Param-Filename  | optional | string    | Filename in Content-Disposition |
 
 #### Query Parameters
@@ -58,8 +58,8 @@ Endpoint: https://dropbox.deploys.app/
 | Name       | Type     | Data Type | Description                     |
 |------------|----------|-----------|---------------------------------|
 | ttl        | optional | number    | 1-7, default 1                  |
-| project    | required | string    | Project name                    |
-| projectId  | optional | string    | Project ID (alternative to project name) |
+| project    | required | string    | Project sid (stable slug)       |
+| projectId  | optional | string    | Numeric project ID (alternative to `project` sid) |
 | filename   | optional | string    | Filename in Content-Disposition |
 
 > Query parameters take precedence over headers when both are provided.

--- a/handler.go
+++ b/handler.go
@@ -53,6 +53,15 @@ func (a *App) uploadHandler(w http.ResponseWriter, r *http.Request) {
 	project := firstNonEmpty(r.URL.Query().Get("project"), r.Header.Get("param-project"))
 	projectID := firstNonEmpty(r.URL.Query().Get("projectId"), r.Header.Get("param-project-id"))
 
+	// `project` accepts either a sid or a numeric project ID. A project sid
+	// always starts with a letter (api ReValidSID: `^[a-z][a-z0-9\-]*[^\-]$`),
+	// so an all-digit value is unambiguously a numeric ID — route it to
+	// projectID, which me.authorized resolves by ID (a sid lookup would fail).
+	// An explicit ?projectId= still wins.
+	if projectID == "" && isAllDigits(project) {
+		projectID, project = project, ""
+	}
+
 	authResult := a.auth(r.Context(), auth, project, projectID)
 	if !authResult.Authorized {
 		jsonFail(w, "api: unauthorized", http.StatusOK)
@@ -220,6 +229,21 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// isAllDigits reports whether s is non-empty and made up solely of ASCII
+// digits. It distinguishes a numeric project ID from a project sid: sids
+// always start with a letter, so they can never be all-digits.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // isInternalClient returns true when the request originates from a

--- a/handler_test.go
+++ b/handler_test.go
@@ -524,6 +524,84 @@ func TestUpload_ProjectParamRouting(t *testing.T) {
 	}
 }
 
+func TestUpload_ProjectNumericRoutesToID(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+
+	var gotProject, gotProjectID string
+	authFn := func(_ context.Context, _, project, projectID string) AuthResult {
+		gotProject, gotProjectID = project, projectID
+		return AuthResult{Authorized: true, Project: Project{ID: "proj-1"}}
+	}
+	app := newTestApp(newTestBucket(t), authFn)
+
+	// An all-digit ?project= is a numeric project ID, not a sid (sids start
+	// with a letter), so it must reach auth as projectID, leaving project empty.
+	body := strings.NewReader("data")
+	r := httptest.NewRequest(http.MethodPost, "/?project=12345", body)
+	r = r.WithContext(db.Ctx())
+	r.ContentLength = 4
+	w := httptest.NewRecorder()
+	app.uploadHandler(w, r)
+
+	if gotProjectID != "12345" {
+		t.Errorf("projectId passed to auth = %q, want 12345", gotProjectID)
+	}
+	if gotProject != "" {
+		t.Errorf("project passed to auth = %q, want empty (numeric routed to projectId)", gotProject)
+	}
+}
+
+func TestUpload_ExplicitProjectIDWinsOverNumericProject(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+
+	var gotProject, gotProjectID string
+	authFn := func(_ context.Context, _, project, projectID string) AuthResult {
+		gotProject, gotProjectID = project, projectID
+		return AuthResult{Authorized: true, Project: Project{ID: "proj-1"}}
+	}
+	app := newTestApp(newTestBucket(t), authFn)
+
+	// An explicit ?projectId= must not be clobbered by the numeric-project
+	// shortcut; project is left as-is (me.authorized prioritizes projectId).
+	body := strings.NewReader("data")
+	r := httptest.NewRequest(http.MethodPost, "/?project=999&projectId=42", body)
+	r = r.WithContext(db.Ctx())
+	r.ContentLength = 4
+	w := httptest.NewRecorder()
+	app.uploadHandler(w, r)
+
+	if gotProjectID != "42" {
+		t.Errorf("projectId passed to auth = %q, want 42 (explicit wins)", gotProjectID)
+	}
+	if gotProject != "999" {
+		t.Errorf("project passed to auth = %q, want 999 (left untouched)", gotProject)
+	}
+}
+
+func TestIsAllDigits(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"":           false,
+		"12345":      true,
+		"0":          true,
+		"acme":       false,
+		"acme-prod":  false,
+		"12a":        false,
+		"a123":       false,
+		" 12":        false,
+		"12 ":        false,
+		"-1":         false,
+		"1.0":        false,
+	}
+	for in, want := range cases {
+		if got := isAllDigits(in); got != want {
+			t.Errorf("isAllDigits(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
 func TestGenerateFilename(t *testing.T) {
 	t.Parallel()
 	a, b := generateFilename(), generateFilename()

--- a/handler_test.go
+++ b/handler_test.go
@@ -494,6 +494,36 @@ func TestUpload_ProjectIDParamRouting(t *testing.T) {
 	}
 }
 
+func TestUpload_ProjectParamRouting(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+
+	var gotProject, gotProjectID string
+	authFn := func(_ context.Context, _, project, projectID string) AuthResult {
+		gotProject, gotProjectID = project, projectID
+		return AuthResult{Authorized: true, Project: Project{ID: "proj-1"}}
+	}
+	app := newTestApp(newTestBucket(t), authFn)
+
+	// ?project= carries the project sid; it must reach auth as `project`
+	// (me.authorized resolves it by sid) and must not be confused with the
+	// numeric `projectId`.
+	body := strings.NewReader("data")
+	r := httptest.NewRequest(http.MethodPost, "/?project=acme-sid", body)
+	r = r.WithContext(db.Ctx())
+	r.ContentLength = 4
+	r.Header.Set("param-project-id", "id-from-header")
+	w := httptest.NewRecorder()
+	app.uploadHandler(w, r)
+
+	if gotProject != "acme-sid" {
+		t.Errorf("project passed to auth = %q, want acme-sid", gotProject)
+	}
+	if gotProjectID != "id-from-header" {
+		t.Errorf("projectId passed to auth = %q, want id-from-header (header fallback)", gotProjectID)
+	}
+}
+
 func TestGenerateFilename(t *testing.T) {
 	t.Parallel()
 	a, b := generateFilename(), generateFilename()


### PR DESCRIPTION
## What

The dropbox upload `project` identifier now accepts **either** a project sid (stable slug) **or** a numeric project ID. Previously `?project=` was relayed to `me.authorized`'s `project` field, which resolves strictly by sid — so a numeric ID handed to `project` failed the sid lookup.

## Why it's unambiguous

A project sid always starts with a letter (api `ReValidSID`: `^[a-z][a-z0-9\-]*[^\-]$`, 6–32 chars), so it can **never** be all-digits. An all-digit `project` value is therefore unambiguously a numeric ID.

## Change

- `uploadHandler`: when `project` is all-digits and no explicit `projectId` was given, route it to `projectID` (resolved by ID). An explicit `?projectId=` still wins. New `isAllDigits` helper.
- README/CLAUDE: document that `project` takes a sid or a numeric ID and how the disambiguation works.
- Tests: numeric-routes-to-ID, explicit-projectId-wins, the existing sid routing, and a unit test for `isAllDigits`. Full suite 95 pass.

No change to the service's auth contract or storage — `me.authorized` still resolves `project` by sid and `projectId` by numeric ID; this only decides which field a `project` value lands in.

Counterpart to deploys-app/api#99 (merged), which made the client send `?project=`. This makes both sid and numeric values work there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)