### PR TITLE
dropbox: support HTTP Range requests in streamFile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,4 @@ Standard Go HTTP server (not Cloudflare Workers) serving as a temporary file upl
 
 - `schema.sql` targets PostgreSQL; `project_id` is `text` (the API returns string IDs)
 - `base_url` is the public download prefix (`https://dropbox.deploys.app/files/`); it shares the service host and resolves to the `GET /files/{token}` route, which streams directly or 307s to the CDN (see `cdn_base_url`)
+- `streamFile` (`files.go`) serves via `http.ServeContent` over `blobReadSeeker`, a lazy `io.ReadSeeker` backed by `Bucket.NewRangeReader`. This gives HTTP `Range` support (`206` + `Content-Range` + `Accept-Ranges`, `416` on an unsatisfiable range) and conditional GETs (`Last-Modified` / `If-Range`) while reading only the requested span from GCS — a range request never reads the whole object, and `HEAD` reads nothing. Egress is billed for the bytes actually written (a `countingResponseWriter`), not `attrs.Size`.

--- a/files.go
+++ b/files.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -188,22 +187,18 @@ func setDeadCacheControl(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(cdnDeadResponseTTL.Seconds())))
 }
 
-// streamFile copies the object body to w with the cached headers. When
-// projectID is non-empty, download_count and egress_bytes are bumped by
-// the actual transferred bytes. Used by both the direct-stream path
-// (no CDN configured) and the unauthenticated _cdn origin path.
+// streamFile writes the object body to w, honoring HTTP Range requests.
+// The object is handed to http.ServeContent as a lazy io.ReadSeeker
+// (blobReadSeeker) so a range request reads only the requested span from
+// the bucket instead of the whole object; ServeContent emits 206 +
+// Content-Range + Accept-Ranges (or 416 on an unsatisfiable range) and the
+// matching Content-Length, and also handles conditional (If-Range /
+// If-Modified-Since) requests against the object's mod time. When projectID
+// is non-empty, download_count is bumped once per request and egress_bytes
+// by the bytes actually written to the client (a range serves fewer than
+// attrs.Size). Used by both the direct-stream path (no CDN configured) and
+// the unauthenticated _cdn origin path.
 func (a *App) streamFile(w http.ResponseWriter, r *http.Request, fn string, attrs *blob.Attributes, projectID string) {
-	reader, err := a.Bucket.NewReader(r.Context(), fn, nil)
-	if err != nil {
-		if gcerrors.Code(err) == gcerrors.NotFound {
-			http.NotFound(w, r)
-			return
-		}
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-	defer reader.Close()
-
 	// Only fall back to the bucket's CacheControl if the caller hasn't
 	// already chosen one. cdnFileHandler pre-sets a TTL-aligned policy;
 	// the non-CDN fileHandler leaves it unset and gets the bucket value.
@@ -213,18 +208,117 @@ func (a *App) streamFile(w http.ResponseWriter, r *http.Request, fn string, attr
 	if attrs.ContentDisposition != "" {
 		w.Header().Set("Content-Disposition", attrs.ContentDisposition)
 	}
+	// Set Content-Type up front so ServeContent uses it verbatim instead of
+	// sniffing (a sniff would cost an extra range read at offset 0). With no
+	// stored type, ServeContent falls back to sniffing the first 512 bytes.
 	if attrs.ContentType != "" {
 		w.Header().Set("Content-Type", attrs.ContentType)
 	}
-	w.Header().Set("Content-Length", strconv.FormatInt(attrs.Size, 10))
 
+	rs := &blobReadSeeker{ctx: r.Context(), bucket: a.Bucket, key: fn, size: attrs.Size}
+	defer rs.Close()
+
+	dst := w
+	var counter *countingResponseWriter
 	if projectID != "" {
 		downloadCount.WithLabelValues(projectID).Inc()
+		counter = &countingResponseWriter{ResponseWriter: w}
+		dst = counter
 	}
-	n, _ := io.Copy(w, reader)
-	if projectID != "" {
-		egressBytes.WithLabelValues(projectID).Add(float64(n))
+
+	// ServeContent parses Range/If-Range and conditional headers, then
+	// streams via rs (which opens a GCS range reader lazily at the requested
+	// offset). name is "" — fn carries no meaningful extension and the
+	// Content-Type is already chosen above.
+	http.ServeContent(dst, r, "", attrs.ModTime, rs)
+
+	if counter != nil {
+		egressBytes.WithLabelValues(projectID).Add(float64(counter.n))
 	}
+}
+
+// blobReadSeeker adapts a GCS object into an io.ReadSeeker backed by lazy
+// range reads, so http.ServeContent can satisfy a Range request by reading
+// only the requested span instead of the whole object. Seeks are pure
+// arithmetic against the known size; the underlying bucket reader is opened
+// (and reopened after a discontiguous seek) lazily on the next Read. Not
+// safe for concurrent use — one per request, which is how ServeContent
+// drives it.
+type blobReadSeeker struct {
+	ctx    context.Context
+	bucket *blob.Bucket
+	key    string
+	size   int64
+
+	offset int64         // virtual cursor: next byte the caller will read
+	rc     io.ReadCloser // current bucket reader, nil until first Read
+	rcAt   int64         // absolute offset of rc's next byte; valid when rc != nil
+}
+
+func (b *blobReadSeeker) Read(p []byte) (int, error) {
+	if b.offset >= b.size {
+		return 0, io.EOF
+	}
+	// (Re)open the bucket reader when we have none, or the cursor has moved
+	// away from where the open reader is positioned (after a Seek).
+	if b.rc == nil || b.rcAt != b.offset {
+		if b.rc != nil {
+			b.rc.Close()
+			b.rc = nil
+		}
+		rc, err := b.bucket.NewRangeReader(b.ctx, b.key, b.offset, -1, nil)
+		if err != nil {
+			return 0, err
+		}
+		b.rc = rc
+		b.rcAt = b.offset
+	}
+	n, err := b.rc.Read(p)
+	b.offset += int64(n)
+	b.rcAt += int64(n)
+	return n, err
+}
+
+func (b *blobReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = b.offset + offset
+	case io.SeekEnd:
+		abs = b.size + offset
+	default:
+		return 0, errors.New("blobReadSeeker: invalid whence")
+	}
+	if abs < 0 {
+		return 0, errors.New("blobReadSeeker: negative position")
+	}
+	b.offset = abs
+	return abs, nil
+}
+
+func (b *blobReadSeeker) Close() error {
+	if b.rc == nil {
+		return nil
+	}
+	err := b.rc.Close()
+	b.rc = nil
+	return err
+}
+
+// countingResponseWriter tallies bytes written to the response body so
+// streamFile can bill egress for the bytes actually sent — a Range response
+// transfers fewer than attrs.Size.
+type countingResponseWriter struct {
+	http.ResponseWriter
+	n int64
+}
+
+func (c *countingResponseWriter) Write(p []byte) (int, error) {
+	n, err := c.ResponseWriter.Write(p)
+	c.n += int64(n)
+	return n, err
 }
 
 // lookupFile fetches the file's project owner and expiration from the DB.

--- a/files_test.go
+++ b/files_test.go
@@ -132,6 +132,104 @@ func TestFileHandler_NoHeadersWhenAttrsEmpty(t *testing.T) {
 	}
 }
 
+// TestFileHandler_Range exercises streamFile's http.ServeContent range
+// handling across the common forms: prefix, mid, open-ended, suffix, full
+// (no Range), and an unsatisfiable range. The shared db/bucket/app are safe
+// because the subtests run sequentially and each writes a distinct fn.
+func TestFileHandler_Range(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+
+	const body = "hello world" // 11 bytes
+
+	cases := []struct {
+		name       string
+		rangeHdr   string
+		wantStatus int
+		wantBody   string
+		wantCR     string // expected Content-Range ("" = don't check)
+		wantCL     string // expected Content-Length ("" = don't check)
+	}{
+		{"prefix", "bytes=0-4", http.StatusPartialContent, "hello", "bytes 0-4/11", "5"},
+		{"middle", "bytes=6-8", http.StatusPartialContent, "wor", "bytes 6-8/11", "3"},
+		{"openEnded", "bytes=6-", http.StatusPartialContent, "world", "bytes 6-10/11", "5"},
+		{"suffix", "bytes=-5", http.StatusPartialContent, "world", "bytes 6-10/11", "5"},
+		{"full", "", http.StatusOK, body, "", "11"},
+		{"unsatisfiable", "bytes=100-200", http.StatusRequestedRangeNotSatisfiable, "", "bytes */11", ""},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := validTestFn(fmt.Sprintf("rng%d", i))
+			writeObject(t, bkt, fn, "text/plain", []byte(body))
+
+			r := httptest.NewRequest(http.MethodGet, "/files/"+signedToken(fn), nil)
+			r = r.WithContext(db.Ctx())
+			r.SetPathValue("token", signedToken(fn))
+			if tc.rangeHdr != "" {
+				r.Header.Set("Range", tc.rangeHdr)
+			}
+			w := httptest.NewRecorder()
+			app.fileHandler(w, r)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", w.Code, tc.wantStatus)
+			}
+			if tc.wantBody != "" && w.Body.String() != tc.wantBody {
+				t.Errorf("body = %q, want %q", w.Body.String(), tc.wantBody)
+			}
+			if tc.wantCR != "" {
+				if cr := w.Header().Get("Content-Range"); cr != tc.wantCR {
+					t.Errorf("Content-Range = %q, want %q", cr, tc.wantCR)
+				}
+			}
+			if tc.wantCL != "" {
+				if cl := w.Header().Get("Content-Length"); cl != tc.wantCL {
+					t.Errorf("Content-Length = %q, want %q", cl, tc.wantCL)
+				}
+			}
+			// Both 200 and 206 advertise range support; ServeContent omits
+			// Accept-Ranges only on the 416.
+			if tc.wantStatus != http.StatusRequestedRangeNotSatisfiable {
+				if ar := w.Header().Get("Accept-Ranges"); ar != "bytes" {
+					t.Errorf("Accept-Ranges = %q, want bytes", ar)
+				}
+			}
+		})
+	}
+}
+
+// TestCDNFileHandler_Range confirms range support is also live on the
+// unauthenticated _cdn origin path the CDN edge fetches from.
+func TestCDNFileHandler_Range(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+
+	fn := validTestFn("cdnrng")
+	writeObject(t, bkt, fn, "text/plain", []byte("hello world"))
+
+	r := httptest.NewRequest(http.MethodGet, "/_cdn/"+signedToken(fn), nil)
+	r = r.WithContext(db.Ctx())
+	r.SetPathValue("token", signedToken(fn))
+	r.Header.Set("Range", "bytes=6-")
+	w := httptest.NewRecorder()
+	app.cdnFileHandler(w, r)
+
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", w.Code)
+	}
+	if got := w.Body.String(); got != "world" {
+		t.Errorf("body = %q, want %q", got, "world")
+	}
+	if cr := w.Header().Get("Content-Range"); cr != "bytes 6-10/11" {
+		t.Errorf("Content-Range = %q, want %q", cr, "bytes 6-10/11")
+	}
+}
+
 func TestLookupFile_FromDB(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)

--- a/handler_test.go
+++ b/handler_test.go
@@ -23,6 +23,22 @@ func newTestBucket(t *testing.T) *blob.Bucket {
 	return bkt
 }
 
+// writeObject stores body under fn in bkt with the given content type
+// (pass "" for none). Mirrors what uploadHandler writes, minus metadata.
+func writeObject(t *testing.T, bkt *blob.Bucket, fn, contentType string, body []byte) {
+	t.Helper()
+	bw, err := bkt.NewWriter(t.Context(), fn, &blob.WriterOptions{ContentType: contentType})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // validTestFn returns an fnLen-char fn drawn from fnAlphabet, with the
 // descriptive suffix preserved so failing tests are still readable.
 // Distinct suffixes produce distinct fns, which keeps parallel tests


### PR DESCRIPTION
## What

`streamFile` now serves through `http.ServeContent` over `blobReadSeeker` — a lazy `io.ReadSeeker` backed by `Bucket.NewRangeReader` — replacing the eager `NewReader` + `io.Copy` + manual `Content-Length`.

This adds HTTP **Range** support to both serving paths (`fileHandler` and the `/_cdn` origin `cdnFileHandler`), which share `streamFile`:

- `206 Partial Content` with `Content-Range` + `Accept-Ranges`
- `416` on an unsatisfiable range
- conditional GETs (`Last-Modified` / `If-Range`)

## Why

Media seeking and resumable/parallel downloaders need byte ranges. Previously every `GET` streamed the whole object with a `200`. Now a range request reads **only the requested span** from GCS via `NewRangeReader`, and a `HEAD` reads **nothing** (`ServeContent` skips the body) — the old `io.Copy` fetched the full object only for net/http to discard it on `HEAD`.

## Behavior notes

- **Egress** is billed for the bytes actually written to the client (a small `countingResponseWriter`), so a range response is no longer over-counted as the full `attrs.Size` on the direct path. The `/_cdn` path keeps `projectID=""` → no metrics, unchanged.
- The lazy seeker exposes size arithmetically (no GCS op for `ServeContent`'s seek-to-end size probe) and only (re)opens a range reader on `Read` after a discontiguous seek.
- **Trade-off:** the eager `NotFound → 404` is gone. The handler already confirms existence via `Bucket.Attributes` immediately before streaming; on the microsecond race where the object is deleted in between, the client now gets a truncated `200`/`206` rather than a `404` (`ServeContent` commits the status before the first lazy read). Window is near-zero.
- `Last-Modified` (from the object mod time) is now emitted, enabling `304` on conditional GETs — correct for immutable per-upload content.

## Tests

`TestFileHandler_Range` covers prefix / mid / open-ended / suffix / full / unsatisfiable; `TestCDNFileHandler_Range` covers a range on the `/_cdn` path. All existing serving tests (`Success`, `NoHeadersWhenAttrsEmpty`, `NotFound`, `RouteIntegration`, CDN redirect/internal) still pass. Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS