### PR TITLE
Reject empty uploads that slip past the ContentLength guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Endpoint: https://dropbox.deploys.app/
 
 #### Body
 
-File data binary
+File data binary. The body must be non-empty — an upload that carries zero
+bytes (including a chunked / unknown-length request that turns out to be empty)
+is rejected with `body empty` and stores nothing.
 
 #### Responses
 

--- a/handler.go
+++ b/handler.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/acoshift/pgsql/pgctx"
 	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
 )
 
 type App struct {
@@ -103,6 +104,13 @@ func (a *App) uploadHandler(w http.ResponseWriter, r *http.Request) {
 	n, err := io.Copy(bw, r.Body)
 	if err != nil {
 		_ = bw.Close()
+		// Close finalizes whatever bytes already streamed, so a mid-stream
+		// failure can leave a partial (or 0-byte) object behind with no DB row.
+		// Remove it for the same reason as the empty-upload case below — GC is
+		// DB-driven and would never reclaim a rowless object.
+		if derr := a.Bucket.Delete(r.Context(), fn); derr != nil && gcerrors.Code(derr) != gcerrors.NotFound {
+			slog.Error("delete partial upload", "fn", fn, "error", derr)
+		}
 		slog.Error("upload file", "error", err)
 		jsonFail(w, "failed to upload", http.StatusInternalServerError)
 		return
@@ -110,6 +118,21 @@ func (a *App) uploadHandler(w http.ResponseWriter, r *http.Request) {
 	if err := bw.Close(); err != nil {
 		slog.Error("finalize upload", "error", err)
 		jsonFail(w, "failed to upload", http.StatusInternalServerError)
+		return
+	}
+
+	// Reject empty uploads. The r.ContentLength == 0 guard above rejects the
+	// common case up front, but a request with an unknown length (chunked
+	// transfer encoding, ContentLength == -1) can still carry an empty body —
+	// that only becomes apparent after io.Copy reports n == 0. Storing a
+	// 0-byte object serves no one and would linger in the bucket, so delete
+	// the object we just finalized and bail before writing any DB row (GC is
+	// DB-driven and would never reclaim a bucket object with no row).
+	if n == 0 {
+		if err := a.Bucket.Delete(r.Context(), fn); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+			slog.Error("delete empty upload", "fn", fn, "error", err)
+		}
+		jsonFail(w, "body empty", http.StatusOK)
 		return
 	}
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -199,6 +199,65 @@ func TestUpload_NilBody(t *testing.T) {
 	}
 }
 
+func TestUpload_EmptyChunkedBody(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+
+	// ContentLength == -1 mimics a chunked / unknown-length request: the early
+	// r.ContentLength == 0 guard does not fire, so emptiness is only detected
+	// after io.Copy streams zero bytes. The handler must still reject it and
+	// leave nothing behind — no bucket object, no DB row.
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	r = r.WithContext(db.Ctx())
+	r.ContentLength = -1
+	w := httptest.NewRecorder()
+	app.uploadHandler(w, r)
+
+	var resp failResp
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.OK {
+		t.Error("expected ok=false for empty chunked body")
+	}
+	if resp.Error.Message != "body empty" {
+		t.Errorf("message = %q, want body empty", resp.Error.Message)
+	}
+	if n := countObjects(t, bkt); n != 0 {
+		t.Errorf("bucket objects = %d, want 0 (empty upload must not leave an object)", n)
+	}
+	if n := db.CountFiles(t); n != 0 {
+		t.Errorf("db files = %d, want 0 (empty upload must not write a row)", n)
+	}
+}
+
+func TestUpload_ChunkedNonEmptyBodySucceeds(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+
+	// The same unknown-length path must still accept a non-empty body: the
+	// n == 0 guard keys off bytes actually streamed, not ContentLength.
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))
+	r = r.WithContext(db.Ctx())
+	r.ContentLength = -1
+	w := httptest.NewRecorder()
+	app.uploadHandler(w, r)
+
+	var resp uploadResp
+	json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.OK {
+		t.Fatal("expected ok=true for non-empty chunked body")
+	}
+	if n := countObjects(t, bkt); n != 1 {
+		t.Errorf("bucket objects = %d, want 1", n)
+	}
+	if n := db.CountFiles(t); n != 1 {
+		t.Errorf("db files = %d, want 1", n)
+	}
+}
+
 func TestUpload_Success(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)


### PR DESCRIPTION
## What

`POST /` already rejects an upload whose `ContentLength` is a known `0`, but a request with an **unknown length** (chunked transfer encoding, `ContentLength == -1`) can still carry an empty body — which only becomes apparent after `io.Copy` reports `n == 0`. That path stored a 0-byte object in GCS **and** a row in `files`. A read error mid-upload could likewise finalize a partial/0-byte object.

## Change

- After the copy, reject `n == 0` with `body empty` and **delete the just-finalized object** before writing any DB row or bumping metrics.
- Also delete the object on the `io.Copy` error path.

GC is DB-driven, so a bucket object with no row would otherwise never be reclaimed — this keeps the "no rowless objects" invariant the new guard relies on.

## Tests

- `TestUpload_EmptyChunkedBody` — unknown-length empty body is rejected and leaves **no** bucket object and **no** DB row.
- `TestUpload_ChunkedNonEmptyBodySucceeds` — the same unknown-length path still accepts a non-empty body.
- Full suite green (`go test ./...`).

No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS