### PR TITLE
Clean up a partial upload on a cancellation-detached context

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -107,10 +107,15 @@ func (a *App) uploadHandler(w http.ResponseWriter, r *http.Request) {
 		// Close finalizes whatever bytes already streamed, so a mid-stream
 		// failure can leave a partial (or 0-byte) object behind with no DB row.
 		// Remove it for the same reason as the empty-upload case below — GC is
-		// DB-driven and would never reclaim a rowless object.
-		if derr := a.Bucket.Delete(r.Context(), fn); derr != nil && gcerrors.Code(derr) != gcerrors.NotFound {
+		// DB-driven and would never reclaim a rowless object. Delete on a
+		// cancellation-detached context: a copy error is usually a client
+		// disconnect, which already canceled r.Context(), and reusing it here
+		// would fail the cleanup and leak the partial object.
+		delCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 10*time.Second)
+		if derr := a.Bucket.Delete(delCtx, fn); derr != nil && gcerrors.Code(derr) != gcerrors.NotFound {
 			slog.Error("delete partial upload", "fn", fn, "error", derr)
 		}
+		cancel()
 		slog.Error("upload file", "error", err)
 		jsonFail(w, "failed to upload", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## What

Follow-up to #23. That PR added a cleanup `Delete` on the `io.Copy` error path of `POST /` so a mid-stream failure doesn't orphan a partial object (GC is DB-driven and never reclaims a rowless object). But it issued the delete on `r.Context()` — and the most common cause of an `io.Copy` error during a streamed upload is the **client disconnecting**, which has already canceled `r.Context()`. So the cleanup was likely to fail with context-canceled and leak the partial object precisely in the case it was meant to handle.

## Change

Issue the cleanup `Delete` on `context.WithoutCancel(r.Context())` with a short timeout, so a client disconnect doesn't also defeat the cleanup.

(Surfaced by an adversarial review of the signed-upload work in #24, which applies the same detached-context pattern to its own rejection paths.)

No schema change, no behavior change on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS