### PR TITLE
Dockerfile: cache Go module + build cache to speed up go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM registry.deploys.app/public/builder
 
 ENV CGO_ENABLED=0
+ENV GOCACHE=/root/.cache/go-build
+ENV GOMODCACHE=/go/pkg/mod
 
 WORKDIR /workspace
 
@@ -8,9 +10,12 @@ ADD .tool-versions .
 RUN asdf install
 
 ADD go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 ADD . .
-RUN go build -o .build/dropbox -ldflags "-w -s" .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o .build/dropbox -ldflags "-w -s" .
 
 FROM gcr.io/distroless/static
 


### PR DESCRIPTION
## What

Speed up the slow part of the image build (`go build`) by persisting Go's caches across builds with BuildKit cache mounts:

```dockerfile
ENV GOCACHE=/root/.cache/go-build
ENV GOMODCACHE=/go/pkg/mod
...
RUN --mount=type=cache,target=/go/pkg/mod \
    go mod download
...
RUN --mount=type=cache,target=/go/pkg/mod \
    --mount=type=cache,target=/root/.cache/go-build \
    go build ...
```

`GOCACHE`/`GOMODCACHE` are pinned via `ENV` so the mount targets match Go's cache dirs exactly (no dependence on the builder image's HOME/GOPATH).

## Why now

Cache mounts live on the BuildKit daemon. On the persistent remote BuildKit they survive across CI runs, so only changed packages recompile and only new modules download. Build-time only — the final image is unchanged. Same change as apiserver#214; part of a workspace-wide rollout.

## Note

The paths assume the `public/builder` image's build user is root (matches the official `golang` layout; no `USER` directive). If it runs non-root the first build fails loudly with `permission denied` — no latent risk. It's the same builder image across these repos, so confirming once covers them all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UujJC8ThyuTr9EwZjnwcox
