### PR TITLE
fix(upload): compare media type only when enforcing pinned Content-Type

### DIFF
--- a/upload_url.go
+++ b/upload_url.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"net/url"
 	"strings"
@@ -259,9 +260,18 @@ func (a *App) uploadDirectHandler(w http.ResponseWriter, r *http.Request) {
 		jsonFail(w, "upload url expired", http.StatusOK)
 		return
 	}
-	if g.ContentType != "" && r.Header.Get("Content-Type") != g.ContentType {
-		jsonFail(w, "content type mismatch", http.StatusOK)
-		return
+	if g.ContentType != "" {
+		// Compare only the media type (type/subtype), ignoring parameters such as
+		// charset/boundary per RFC 7231 §3.1.1.1: a client sending
+		// "application/json; charset=utf-8" against a grant for "application/json"
+		// is the same media type. ParseMediaType also lowercases, so the match is
+		// case-insensitive; a malformed/empty header parses to "" and is rejected.
+		got, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		want, _, _ := mime.ParseMediaType(g.ContentType)
+		if got != want {
+			jsonFail(w, "content type mismatch", http.StatusOK)
+			return
+		}
 	}
 	if r.Body == nil {
 		jsonFail(w, "body empty", http.StatusOK)

--- a/upload_url_test.go
+++ b/upload_url_test.go
@@ -470,6 +470,29 @@ func TestUploadDirect_ContentTypeMismatch(t *testing.T) {
 	}
 }
 
+// TestUploadDirect_ContentTypeAllowsParams guards that a charset/boundary
+// parameter on the granted media type is accepted — the content-type check
+// compares media types (type/subtype) only, not the raw header.
+func TestUploadDirect_ContentTypeAllowsParams(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	bkt := newTestBucket(t)
+	app := newTestApp(bkt, authorized)
+
+	resp := issueUploadURL(t, app, db, uploadURLRequest{Project: "p", ContentType: "application/pdf", MaxSize: 100})
+	token := uploadTokenOf(t, resp.Result.UploadURL)
+
+	w := doPut(t, app, db, token, "application/pdf; charset=utf-8", "data")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+	var pr putResp
+	json.NewDecoder(w.Body).Decode(&pr)
+	if !pr.OK {
+		t.Fatalf("expected ok=true (charset param on granted media type accepted), got %s", w.Body.String())
+	}
+}
+
 func TestUploadDirect_InvalidToken(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)


### PR DESCRIPTION
## What

The signed direct-upload handler (`PUT /uploads/{token}`) enforced the grant's pinned `Content-Type` with an **exact string match**:

```go
if g.ContentType != "" && r.Header.Get("Content-Type") != g.ContentType {
    jsonFail(w, "content type mismatch", http.StatusOK)
    return
}
```

So a client that adds a standard parameter — e.g. `application/pdf; charset=utf-8` against a grant for `application/pdf` — was wrongly rejected, even though it's the **same media type**.

Fix: compare only the media type (type/subtype) via `mime.ParseMediaType` on both sides, per RFC 7231 §3.1.1.1.

## Why it's safe (not a constraint bypass)

- The body is streamed to storage **without sniffing**, so the pin was always a *declared-media-type* check, never a content guarantee. Ignoring parameters that don't change the media type preserves exactly that constraint.
- A real mismatch is still rejected: `text/plain` vs `application/pdf` → `got != want` → fail (existing `TestUploadDirect_ContentTypeMismatch` still passes).
- **Fail-closed**: a malformed/empty client `Content-Type` parses to `""` and is rejected when the grant pins a type.
- `ParseMediaType` lowercases, so the comparison is correctly case-insensitive (media types are case-insensitive per RFC) — not a regression.
- Still gated by `g.ContentType != ""` (unpinned grants accept anything, unchanged).

## Tests

`TestUploadDirect_ContentTypeAllowsParams`: grant `application/pdf`, PUT `application/pdf; charset=utf-8` → `200 ok`. Genuine regression guard (fails on the old exact-match). The existing mismatch test is retained.

## Verification

- `go build ./...` ok; `gofmt`/`go vet` clean.
- `go test -run TestUploadDirect_ContentType .` — 2 pass (mismatch + new allows-params); dropbox tests run on the in-memory bucket.