### PR TITLE
chore: bump Go to 1.27.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.3
+golang 1.27.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module moonrhythm/dropbox
 
-go 1.26.3
+go 1.27.0
 
 replace github.com/lib/pq => github.com/moonrhythm/pq v0.0.0-20230504040008-09b0644d6569
 


### PR DESCRIPTION
- go.mod: 1.26.3 -> 1.27.0
- .tool-versions: golang 1.27.0