### PR TITLE
chore: modernize to Go 1.27 idioms

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -239,12 +239,10 @@ func TestCheckAuth_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 	for i := range N {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
-			results[idx] = checkAuth(context.Background(), token, "sfproject", "")
-		}(i)
+			results[i] = checkAuth(context.Background(), token, "sfproject", "")
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/files_test.go
+++ b/files_test.go
@@ -295,12 +295,10 @@ func TestLookupFile_SingleflightCollapsesConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 	for i := range N {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start // release all goroutines at once to maximise overlap
-			results[idx] = lookupFile(ctx, fn)
-		}(i)
+			results[i] = lookupFile(ctx, fn)
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/upload_url.go
+++ b/upload_url.go
@@ -105,11 +105,10 @@ func makeUploadToken(key []byte, g uploadGrant) (string, error) {
 // or signature failure returns (_, false) before any DB or bucket work — the
 // same CPU-only shield the download path uses.
 func parseUploadToken(key []byte, token string) (uploadGrant, bool) {
-	i := strings.LastIndexByte(token, uploadTokenSep[0])
-	if i <= 0 || i == len(token)-1 {
+	payload, sig, ok := strings.CutLast(token, uploadTokenSep)
+	if !ok || payload == "" || sig == "" {
 		return uploadGrant{}, false
 	}
-	payload, sig := token[:i], token[i+1:]
 	if !hmac.Equal([]byte(sig), []byte(uploadSig(key, payload))) {
 		return uploadGrant{}, false
 	}
@@ -175,10 +174,7 @@ func (a *App) uploadURLHandler(w http.ResponseWriter, r *http.Request) {
 	if maxSize <= 0 || maxSize > maxCap {
 		maxSize = maxCap
 	}
-	minSize := req.MinSize
-	if minSize < 1 {
-		minSize = 1
-	}
+	minSize := max(req.MinSize, 1)
 	if minSize > maxSize {
 		jsonFail(w, "minSize greater than maxSize", http.StatusOK)
 		return


### PR DESCRIPTION
Stacked on `chore/go-1.27.0`. Behavior-preserving idiom updates only:

- **minmax** (`go fix`): `minSize := max(req.MinSize, 1)`
- **CutLast**: `parseUploadToken` splits on the last separator with `strings.CutLast`
- **waitgroupgo**: singleflight tests use `wg.Go` instead of `Add`/`Done`

No omitzero, json/v2, or public API changes.

Verified: `go build ./... && go vet ./... && go test ./... -count=1 -timeout 300s`